### PR TITLE
Add dependencies to composer manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+     "require": {
+         "lns/social-feed": "~0.2"
+     }
+}

--- a/social_wall.info
+++ b/social_wall.info
@@ -5,4 +5,5 @@ files[] = tests/social_wall.test
 dependencies[] = libraries
 dependencies[] = image
 dependencies[] = imagecache_external
+dependencies[] = composer_manager
 


### PR DESCRIPTION
Cette PR ajoute une dépendance au module `Composer manager` qui permet de lancer automatiquement une installation des éléments du fichier `composer.json` présent dans le module.

C'est un moyen simple et couramment utilisé pour simplifier l'installation d'un module lorsqu'il a des dépendances externes.